### PR TITLE
Refactored IntegrationTestBase to use not-shared free port

### DIFF
--- a/src/it/scala/performanceanalysis/base/IntegrationTestBase.scala
+++ b/src/it/scala/performanceanalysis/base/IntegrationTestBase.scala
@@ -7,14 +7,29 @@ import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, RequestBuilder, Response}
 import com.twitter.io.Bufs._
 import com.twitter.util.Future
+import com.typesafe.config.ConfigFactory
 import org.scalatest._
-import performanceanalysis.server.Main
+import performanceanalysis.administrator.Administrator
+import performanceanalysis.logreceiver.LogReceiver
+import performanceanalysis.server.{Config, Main}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.util.Try
 
 trait IntegrationTestBase extends FeatureSpec with GivenWhenThen with Matchers with BeforeAndAfterAll {
-  val main = Main
+
+  trait TestConfig extends Config {
+    override lazy val adminHttpInterface = "localhost"
+    override lazy val adminHttpPort: Int = 0
+    override lazy val logReceiverHttpInterface = "localhost"
+    override lazy val logReceiverHttpPort: Int = 0
+  }
+
+  val testMain = new App with TestConfig {
+    val logReceiver = new LogReceiver with TestConfig
+    val administrator = new Administrator(logReceiver.logReceiverActor) with TestConfig
+  }
 
   var adminServerAddress: InetSocketAddress = _
   var adminRequestHost: String = _
@@ -24,14 +39,14 @@ trait IntegrationTestBase extends FeatureSpec with GivenWhenThen with Matchers w
   var logReceiverRequestHost: String = _
   var logReceiverClient: Service[Request, Response] = _
 
-  main.main(Array())
+  testMain.main(Array())
 
   override def beforeAll(): Unit = {
-    adminServerAddress = Await.result(main.administrator.getServerAddress, 10.seconds)
+    adminServerAddress = Await.result(testMain.administrator.getServerAddress, 10.seconds)
     adminRequestHost = s"localhost:${adminServerAddress.getPort.toString}"
     adminClient = finagle.Http.newService(adminRequestHost)
 
-    logReceiverServerAddress = Await.result(main.logReceiver.getServerAddress, 10.seconds)
+    logReceiverServerAddress = Await.result(testMain.logReceiver.getServerAddress, 10.seconds)
     logReceiverRequestHost = s"localhost:${logReceiverServerAddress.getPort.toString}"
     logReceiverClient = finagle.Http.newService(logReceiverRequestHost)
   }

--- a/src/main/scala/performanceanalysis/server/Config.scala
+++ b/src/main/scala/performanceanalysis/server/Config.scala
@@ -1,16 +1,16 @@
 package performanceanalysis.server
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ConfigFactory, Config => TypesafeConfig}
 
 import scala.util.Try
 
 trait Config {
-  protected lazy val config = ConfigFactory.load()
-  protected lazy val httpConfig = Try(config.getConfig("http")).getOrElse(ConfigFactory.empty())
-  protected lazy val adminHttpConfig = Try(httpConfig.getConfig("admin")).getOrElse(ConfigFactory.empty())
-  protected lazy val logReceiverHttpConfig = Try(httpConfig.getConfig("logReceiver")).getOrElse(ConfigFactory.empty())
-  lazy val adminHttpInterface = Try(adminHttpConfig.getString("interface")).getOrElse("0.0.0.0")
+  protected lazy val config: TypesafeConfig = ConfigFactory.load()
+  protected lazy val httpConfig: TypesafeConfig = Try(config.getConfig("http")).getOrElse(ConfigFactory.empty())
+  protected lazy val adminHttpConfig: TypesafeConfig = Try(httpConfig.getConfig("admin")).getOrElse(ConfigFactory.empty())
+  protected lazy val logReceiverHttpConfig: TypesafeConfig = Try(httpConfig.getConfig("logReceiver")).getOrElse(ConfigFactory.empty())
+  lazy val adminHttpInterface: String = Try(adminHttpConfig.getString("interface")).getOrElse("0.0.0.0")
   lazy val adminHttpPort: Int = Try(adminHttpConfig.getInt("port")).getOrElse(0)
-  lazy val logReceiverHttpInterface = Try(logReceiverHttpConfig.getString("interface")).getOrElse("0.0.0.0")
+  lazy val logReceiverHttpInterface: String = Try(logReceiverHttpConfig.getString("interface")).getOrElse("0.0.0.0")
   lazy val logReceiverHttpPort: Int = Try(logReceiverHttpConfig.getInt("port")).getOrElse(0)
 }


### PR DESCRIPTION
Added mixin of `TestConfig` to overrule port
